### PR TITLE
Fix occasionally wrong metadata emission for pseudo-instructions.

### DIFF
--- a/llvm/include/llvm/CodeGen/MachineInstr.h
+++ b/llvm/include/llvm/CodeGen/MachineInstr.h
@@ -119,7 +119,8 @@ public:
     IsCall       = 1 << 22,
     IsReturn     = 1 << 23,
     IsBranch     = 1 << 24,
-    MaxFlagShift = 24
+    IsTailCall   = 1 << 25,             // A branch instruction that also acts as a tail call.
+    MaxFlagShift = 25
   };
 
 private:

--- a/llvm/lib/CodeGen/MachineInstr.cpp
+++ b/llvm/lib/CodeGen/MachineInstr.cpp
@@ -1560,6 +1560,8 @@ void MachineInstr::print(raw_ostream &OS, ModuleSlotTracker &MST,
     OS << "is-return ";
   if (getFlag(MachineInstr::IsBranch))
     OS << "is-branch ";
+  if (getFlag(MachineInstr::IsTailCall))
+    OS << "is-tail-call ";
 
   // Print the opcode name.
   if (TII)

--- a/llvm/lib/Target/RISCV/ISPAsmPrinter.cpp
+++ b/llvm/lib/Target/RISCV/ISPAsmPrinter.cpp
@@ -93,14 +93,13 @@ static void LowerToSSITHEpilogStore64(const MachineInstr *MI, MCInst &OutMI,
 }
 
 void ISPAsmPrinter::EmitInstruction(const MachineInstr *MI) {
-  
   RISCVAsmPrinter::EmitInstruction(MI);
 
   // fn range avoids NoCFI on C code stuff
   // TODO: this may or may not be in the "right" place...
-  if(MI->isReturn()) 
+  if(MI->isReturn() || MI->getFlag(MachineInstr::IsTailCall)) {
     EmitFnRangeMetadata(CurrentFnSym, OutContext.createTempSymbol());
-
+  }
   //SSITH - clean up in function epilog
   if(MI->getFlag(MachineInstr::FnEpilog) && MI->getOpcode() == RISCV::LW){
     //Emit our new store

--- a/llvm/lib/Target/RISCV/ISPMetadataPass.cpp
+++ b/llvm/lib/Target/RISCV/ISPMetadataPass.cpp
@@ -45,10 +45,14 @@ static void setMIFlags(MachineInstr *MI) {
     MI->setFlag(MachineInstr::IsReturn);
     MI->setFlag(MachineInstr::FnEpilog);
   }
+
+  // These two used to use MI->setFlag() instead, which broke the tailcall tagging.
+  // I tried to see whether machine instructions ever have flags that may cause issues,
+  // but I couldn't find any cases of that.
   else if ( MI->isCall() )
-    MI->setFlags(MachineInstr::IsCall);
+    MI->setFlag(MachineInstr::IsCall);
   else if ( MI->isBranch() )
-    MI->setFlags(MachineInstr::IsBranch);
+    MI->setFlag(MachineInstr::IsBranch);
   
 }
   

--- a/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
+++ b/llvm/lib/Target/RISCV/RISCVExpandPseudoInsts.cpp
@@ -134,12 +134,17 @@ bool RISCVExpandPseudo::expandPseudoBranch(MachineBasicBlock &MBB,
    .add(*Func);
 
   if (MI.getOpcode() == RISCV::PseudoTAIL ||
-      MI.getOpcode() == RISCV::PseudoJump)
+      MI.getOpcode() == RISCV::PseudoJump) {
     // Emit JALR X0, Ra, 0
-    BuildMI(MBB, NextMBBI, DL, TII->get(RISCV::JALR), RISCV::X0)
+    auto &JMI = BuildMI(MBB, NextMBBI, DL, TII->get(RISCV::JALR), RISCV::X0)
       .addReg(Ra)
       .addImm(0);
-  else
+
+    // Mark tailcall instructions so that function range metadata is still correct.
+    if (MI.getOpcode() == RISCV::PseudoTAIL) {
+       JMI.setMIFlag(MachineInstr::IsTailCall);
+    }
+  } else
     // Emit JALR Ra, Ra, 0
     BuildMI(MBB, NextMBBI, DL, TII->get(RISCV::JALR), Ra)
       .addReg(Ra)


### PR DESCRIPTION
Due to when the ISP metadata pass is done, there may still be some pseudo-instructions that have metadata attached. This poses a problem because the metadata location will be incorrect if we're trying to put it at the end of a basic block or on specific control flow transfer instructions.

Marking this as a draft until I add tests.